### PR TITLE
Publish window parameter as Denite gitn_log's second argument

### DIFF
--- a/doc/gitn.txt
+++ b/doc/gitn.txt
@@ -8,6 +8,8 @@ CONTENTS					*gitn-contents*
 
 Introduction		|gitn-introduction|
 Install			|gitn-install|
+Example settings	|gitn-example-settings|
+Usage			|gitn-usage|
 
 
 ==========================================================================
@@ -21,7 +23,8 @@ INSTALL						*gitn-install*
 
 If you use dein.nvim, add `kmnk/gitn` repo to your dein setting toml file.
 
-Example: >
+Example:
+>
     [[plugins]]
     repo = 'kmnk/gitn'
 <
@@ -48,7 +51,7 @@ EXAMPLE SETTINGS					*gitn-example-settings*
     nmap [denite]gl <SID>(git-log)
 
     nnoremap <silent> <SID>(git-status) :<C-u>Denite gitn_status<CR>
-    nnoremap <silent> <SID>(git-status) :<C-u>Denite gitn_log<CR>
+    nnoremap <silent> <SID>(git-status) :<C-u>Denite gitn_log::tab<CR>
 <
 
 ==========================================================================
@@ -56,12 +59,18 @@ USAGE					*gitn-usage*
 
 Pass |gitn| source with gitn subcommand to |:Denite| .
 
-Show status: >
-    :Denite gitn_status
+:Denite gitn_status					*gitn-usage-status*
+		Format and list the 'git status' command results.
 
-Show log: >
-    :Denite gitn_log
+:Denite gitn_log[:{file_name}[:{open_diff_method}]]	*gitn-usage-log*
+		Format and list the 'git log' command results.
+		If specify first parameter, log only that file.
+		If specify second parameter, open diff as specified method.
+			"current": open on current buffer
+			"tab": open on new tab buffer
+			"split": open on new splitted buffer
+			"vsplit": open on new vertical splitted buffer
 
 
 ==========================================================================
-vim:tw=78:ts=8:ft=help:norl:noet:fen:fdl=0:
+vim:tw=78:ts=8:ft=help:norl:noet:fen:

--- a/rplugin/python3/denite/kind/gitn_log.py
+++ b/rplugin/python3/denite/kind/gitn_log.py
@@ -84,9 +84,11 @@ class Kind(Base):
             t,
             self.__join(self.__to_paths(targets))
         ))
+
+        window = targets[0]['action__window']
         if len(diff) > 0:
             Gitn.open_window(self.vim, {
-                'window': Window.tab,
+                'window': Window.by(window) if Window.has(window) else Window.tab,
                 'text': diff,
                 'filetype': 'diff',
                 'buftype': 'nofile',

--- a/rplugin/python3/denite/source/gitn_log.py
+++ b/rplugin/python3/denite/source/gitn_log.py
@@ -2,6 +2,7 @@
 # Author: kmnk <kmnknmk at gmail.com>
 # License: MIT license
 
+from gitn.enum import Window
 from gitn.util.gitn import Gitn
 from denite.process import Process
 import os
@@ -66,15 +67,22 @@ class Source(Base):
             ],
             'separator': ['--'],
             'file': [''],
+            'window': 'tab',
         }
 
     def on_init(self, context):
         self.__proc = None
 
-        if len(context['args']) < 1:
-            self.vars['file'] = ['']
-        else:
+        if len(context['args']) >= 1:
             self.vars['file'] = [context['args'][0]]
+        else:
+            self.vars['file'] = ['']
+
+        if len(context['args']) >= 2:
+            if Window.has(context['args'][1]):
+                self.vars['window'] = context['args'][1]
+            else:
+                self.vars['window'] = 'tab'
 
     def on_close(self, context):
         if self.__proc:
@@ -124,7 +132,8 @@ class Source(Base):
                             result['subject'],
                         ),
                         'action__log': result,
-                        'action__path': context['args'][1] if len(context['args']) >= 2 else '',
+                        'action__path': context['args'][0] if len(context['args']) >= 1 else '',
+                        'action__window': self.vars['window'],
                     })
                 elif 'graph' in result:
                     candidates.append({

--- a/rplugin/python3/gitn/enum.py
+++ b/rplugin/python3/gitn/enum.py
@@ -18,6 +18,19 @@ class Window(Enum):
         if window == cls.vsplit: return 'vnew'
         return 'enew'
 
+    @classmethod
+    def has(cls, value):
+        value = value.lower()
+        for name, member in cls.__members__.items():
+            if name == value: return True
+        return False
+
+    @classmethod
+    def by(cls, value):
+        value = value.lower()
+        for name, member in cls.__members__.items():
+            if name == value: return member
+        raise ValueError()
 
 @unique
 class Status(Enum):


### PR DESCRIPTION
Enable window parameter as second argumennt of gitn_log.

For examble, if want to open git diff on current buffer, execute below command.

```
Denite gitn_log::current
```
Description of this option is added to doc/gitn.txt .