### PR TITLE
Use bang version of `normal`

### DIFF
--- a/rplugin/python3/denite/kind/gitn_log.py
+++ b/rplugin/python3/denite/kind/gitn_log.py
@@ -133,8 +133,8 @@ class Kind(Base):
                 t,
                 self.__join(self.__to_paths(targets))
             ))
-            self.vim.command('keepjumps normal G')
-            self.vim.command('keepjumps normal gg')
+            self.vim.command('keepjumps normal! G')
+            self.vim.command('keepjumps normal! gg')
             self.vim.command('delete')
 
         self.vim.call('win_gotoid', prev_id)


### PR DESCRIPTION
This fixes the problem described in this comment https://github.com/kmnk/gitn/pull/11#issuecomment-403295572

Such problem can be reproduced with the following minimal vimrc
```vim
set nocompatible

let $DOTVIM = expand('$HOME/.vim')

set runtimepath+=$DOTVIM/bundle/repos/github.com/Shougo/denite.nvim
set runtimepath+=$DOTVIM/bundle/repos/github.com/kmnk/gitn
filetype plugin indent on


" Move to the end of the line when using G (and open existing fold)
nnoremap <silent> G Gzo$

nnoremap ,gl :Denite -auto-preview -default-action=diff
            \ -no-quit gitn_log:*:current<CR>
```